### PR TITLE
Optional nginx config for Password Protection of frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ It will start the frontend on port `3000`.
 - `BACKEND_URL`: The URL of the backend. Default should work in most cases. You can also replace it with container name of backend if you are using docker-compose.
 
 ---
-## NGINX Configuration
+## NGINX Configuration *Optional*
 
 ### Install NGINX if not already
 

--- a/nginx-conf
+++ b/nginx-conf
@@ -1,0 +1,38 @@
+server {
+    listen 80;
+    server_name IP/DOMAIN;
+
+    # Main location block to serve your application at /
+    location / {
+        auth_basic "Restricted Area";  # This is the realm name that will appear in the authentication dialog
+        auth_basic_user_file /etc/nginx/.htpasswd;
+        
+        proxy_pass http://127.0.0.1:3000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        
+        proxy_set_header Origin http://127.0.0.1:3000;
+
+        # Prevent proxying loops
+        proxy_redirect off;
+
+        # Allow serving static assets correctly
+        try_files $uri $uri/ @proxy;
+
+        # Disable buffering for proxied responses
+        proxy_buffering off;
+    }
+
+    # Fallback for anything that doesn't match
+    location @proxy {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        
+        proxy_set_header Origin http://127.0.0.1:3000;
+    }
+}

--- a/nginx-conf
+++ b/nginx-conf
@@ -1,9 +1,10 @@
 server {
     listen 80;
-    server_name IP/DOMAIN;
+    server_name IP/DOMAIN; # Change to your Public IP Address or use a Domain with DNS A Record pointed to your Public IP address
 
     # Main location block to serve your application at /
     location / {
+        # Create a user ` htpasswd -c /etc/nginx/.htpasswd USERNAMEHERE `
         auth_basic "Restricted Area";  # This is the realm name that will appear in the authentication dialog
         auth_basic_user_file /etc/nginx/.htpasswd;
         
@@ -12,6 +13,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
         
         proxy_set_header Origin http://127.0.0.1:3000;
 
@@ -32,6 +34,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
         
         proxy_set_header Origin http://127.0.0.1:3000;
     }


### PR DESCRIPTION
NGINX configuration template that serves an application hosted on a Docker container at http://127.0.0.1:3000. This configuration includes basic authentication to restrict access to the application, ensuring that only authorized users can view the content.

Create User - 
`htpasswd -c /etc/nginx/.htpasswd USERNAMEHERE`

Docker Compose Example -

```  
riven-frontend:
    image: spoked/riven-frontend:latest
    container_name: riven-frontend
    restart: unless-stopped
    ports:
      - "127.0.0.1:3000:3000"
    tty: true
    environment:
      - PUID=1000
      - PGID=1000
      - TZ=Europe/London
      - ORIGIN=http://127.0.0.1:3000 # set to the url or ip where the frontend is hosted
      - BACKEND_URL=http://riven:8080
      - DIALECT=postgres
      - DATABASE_URL=postgres://postgres:postgres@riven-db/riven
    depends_on:
      riven:
        condition: service_healthy
```