### PR TITLE
fix: Prevent /api requests from being redirected to /onboarding

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -12,7 +12,7 @@ const setLocals: Handle = async ({ event, resolve }) => {
 };
 
 const onboarding: Handle = async ({ event, resolve }) => {
-	if (!event.url.pathname.startsWith('/onboarding') && event.request.method === 'GET') {
+	if (!(event.url.pathname.startsWith('/onboarding') || event.url.pathname.startsWith('/api')) && event.request.method === 'GET') {
 		const { data, error: apiError } = await DefaultService.services();
 		if (apiError || !data) {
 			return error(500, 'API Error');


### PR DESCRIPTION
This aims to fix the issue described in https://github.com/rivenmedia/riven-frontend/issues/139 by preventing requests to the `/api` path from being automatically redirected to `/onboarding`. 