### PR TITLE
feat: add reset and retry buttons to episode cards

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,7 +27,7 @@ export default [
 			}
 		},
 		rules: {
-			'no-console': 'warn',
+			'no-console': ['warn', { allow: ['warn', 'error'] }],
 			'@typescript-eslint/no-unused-vars': [
 				'warn',
 				{

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 import { fontFamily } from 'tailwindcss/defaultTheme';
 import type { Config } from 'tailwindcss';
+import { blur } from 'svelte/transition';
 
 const config: Config = {
 	darkMode: ['class'],
@@ -85,6 +86,20 @@ const config: Config = {
 					transparent 10px,
 					transparent 20px
 					)`
+			},
+			keyframes: {
+				'blur-in': {
+					'0%': { filter: 'blur(0px)' },
+					'100%': { filter: 'blur(4px)' }
+				},
+				'blur-out': {
+					'0%': { filter: 'blur(4px)' },
+					'100%': { filter: 'blur(0px)' }
+				}
+			},
+			animation: {
+				'blur-in': 'blur-in 0.5s forwards',
+				'blur-out': 'blur-out 0.5s forwards'
 			}
 		}
 	}


### PR DESCRIPTION
Add reset and retry functionality to episode cards:
- Add click-to-show action buttons on episode cards
- Implement reset and retry functionality
- Add visual feedback with blur effect and overlay
- Show success/error toasts for actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced media episode management with new action buttons for resetting and retrying episodes.
	- Introduced visual feedback with animation effects on selected episodes.
	- Added icons for improved user interface.
	- Implemented functionality to track and toggle selected episodes.
	- Added keyboard accessibility for episode selection.

- **Bug Fixes**
	- Improved user notifications for success or failure of media item actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->