### PR TITLE
Fix Emby & Jellyfin API_KEY setting

### DIFF
--- a/src/lib/forms/helpers.ts
+++ b/src/lib/forms/helpers.ts
@@ -233,10 +233,10 @@ export function mediaServerSettingsToPass(data: any) {
 		plex_token: data.updaters.plex.token,
 		plex_url: data.updaters.plex.url,
 		plex_enabled: data.updaters.plex.enabled,
-		jellyfin_token: data.updaters.jellyfin.token,
+		jellyfin_token: data.updaters.jellyfin.api_key,
 		jellyfin_url: data.updaters.jellyfin.url,
 		jellyfin_enabled: data.updaters.jellyfin.enabled,
-		emby_token: data.updaters.emby.token,
+		emby_token: data.updaters.emby.api_key,
 		emby_url: data.updaters.emby.url,
 		emby_enabled: data.updaters.emby.enabled
 	};
@@ -255,12 +255,12 @@ export function mediaServerSettingsToSet(form: SuperValidated<Infer<MediaServerS
 				},
 				jellyfin: {
 					enabled: form.data.jellyfin_enabled,
-					token: form.data.jellyfin_token,
+					api_key: form.data.jellyfin_token,
 					url: form.data.jellyfin_url
 				},
 				emby: {
 					enabled: form.data.emby_enabled,
-					token: form.data.emby_token,
+					api_key: form.data.emby_token,
 					url: form.data.emby_url
 				}
 			}


### PR DESCRIPTION
Hello,
The current version of the frontend fails to set Emby & Jellyfin api keys.

Thank you,

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated media server configuration settings by changing the authentication label from “token” to “API Key” for both Jellyfin and Emby. This update enhances clarity and consistency during setup, reducing ambiguity when entering server credentials for a smoother configuration experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->