### PR TITLE
feat: implement breadcrumb navigation for media pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,10 @@ bun.lockb
 /config
 server-config.json
 openapi*.log
+
+# Test scripts and temporary documentation
+setup-and-run.sh
+run-dev.sh
+*_BREADCRUMB*.md
+BREADCRUMB_*.md
+test-*.sh

--- a/src/lib/components/navigation-breadcrumb.svelte
+++ b/src/lib/components/navigation-breadcrumb.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+	import { ChevronRight, Library } from 'lucide-svelte';
+	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
+	import { cn } from '$lib/utils';
+
+	export interface BreadcrumbItem {
+		label: string;
+		href: string;
+		isActive?: boolean;
+		dropdown?: DropdownItem[];
+	}
+
+	export interface DropdownItem {
+		label: string;
+		href: string;
+		isActive?: boolean;
+		badge?: string;
+	}
+
+	export let items: BreadcrumbItem[] = [];
+	export let className: string = '';
+</script>
+
+<nav
+	aria-label="Breadcrumb"
+	class={cn('flex items-center space-x-1 text-sm text-zinc-400', className)}
+>
+	{#each items as item, index}
+		{#if index > 0}
+			<ChevronRight class="h-4 w-4 flex-shrink-0" />
+		{/if}
+
+		{#if item.dropdown && item.dropdown.length > 0}
+			<DropdownMenu.Root>
+				<DropdownMenu.Trigger class="group flex items-center gap-1 hover:text-zinc-100">
+					{#if index === 0}
+						<Library class="h-4 w-4" />
+					{/if}
+					<span
+						class={cn(
+							'transition-colors',
+							item.isActive ? 'text-zinc-100 font-medium' : 'hover:text-zinc-100'
+						)}
+					>
+						{item.label}
+					</span>
+					<ChevronRight class="h-3 w-3 rotate-90 transition-transform group-data-[state=open]:rotate-[270deg]" />
+				</DropdownMenu.Trigger>
+				<DropdownMenu.Content align="start" class="max-h-[400px] overflow-y-auto">
+					{#each item.dropdown as dropdownItem}
+						<DropdownMenu.Item asChild>
+							<a
+								href={dropdownItem.href}
+								class={cn(
+									'flex items-center justify-between gap-2',
+									dropdownItem.isActive && 'bg-zinc-800'
+								)}
+							>
+								<span>{dropdownItem.label}</span>
+								{#if dropdownItem.badge}
+									<span class="text-xs text-zinc-500">{dropdownItem.badge}</span>
+								{/if}
+							</a>
+						</DropdownMenu.Item>
+					{/each}
+				</DropdownMenu.Content>
+			</DropdownMenu.Root>
+		{:else}
+			<a
+				href={item.href}
+				class={cn(
+					'flex items-center gap-1 transition-colors',
+					item.isActive ? 'text-zinc-100 font-medium' : 'hover:text-zinc-100'
+				)}
+			>
+				{#if index === 0}
+					<Library class="h-4 w-4" />
+				{/if}
+				<span>{item.label}</span>
+			</a>
+		{/if}
+	{/each}
+</nav> 

--- a/src/lib/utils/breadcrumb.ts
+++ b/src/lib/utils/breadcrumb.ts
@@ -1,0 +1,126 @@
+import type { BreadcrumbItem, DropdownItem } from '$lib/components/navigation-breadcrumb.svelte';
+import { statesName } from '$lib/constants';
+
+interface BreadcrumbOptions {
+	mediaType?: 'movie' | 'tv';
+	mediaId?: string;
+	mediaTitle?: string;
+	seasonNumber?: number;
+	seasonData?: any;
+	episodeNumber?: number;
+	episodeTitle?: string;
+	allSeasons?: any[];
+	allEpisodes?: any[];
+	rivenData?: any;
+}
+
+export function buildBreadcrumbs(options: BreadcrumbOptions): BreadcrumbItem[] {
+	const items: BreadcrumbItem[] = [];
+
+	// Always start with Library/Browse
+	items.push({
+		label: 'Library',
+		href: '/browse',
+		isActive: false
+	});
+
+	// Add media type if available
+	if (options.mediaType) {
+		const mediaTypeLabel = options.mediaType === 'movie' ? 'Movies' : 'TV Shows';
+		const apiMediaType = options.mediaType === 'tv' ? 'show' : 'movie';
+		items.push({
+			label: mediaTypeLabel,
+			href: `/browse?type=${apiMediaType}`,
+			isActive: !options.mediaId
+		});
+	}
+
+	// Add media title if available
+	if (options.mediaId && options.mediaTitle) {
+		items.push({
+			label: options.mediaTitle,
+			href: `/${options.mediaType}/${options.mediaId}`,
+			isActive: options.seasonNumber === undefined
+		});
+	}
+
+	// Add season if available
+	if (options.seasonNumber !== undefined && options.mediaType === 'tv') {
+		const seasonItem: BreadcrumbItem = {
+			label: `Season ${options.seasonNumber}`,
+			href: `/tv/${options.mediaId}/${options.seasonNumber}`,
+			isActive: options.episodeNumber === undefined
+		};
+
+		// Add dropdown for other seasons if available
+		if (options.allSeasons && options.allSeasons.length > 1) {
+			seasonItem.dropdown = options.allSeasons
+				.filter(season => season.season_number !== 0) // Filter out specials
+				.sort((a, b) => a.season_number - b.season_number) // Sort by season number
+				.map(season => {
+					// Handle different Riven data structures
+					let rivenSeason = null;
+					if (options.rivenData) {
+						if (options.rivenData.seasons) {
+							// Full show data structure
+							rivenSeason = options.rivenData.seasons.find((s: any) => s.number === season.season_number);
+						}
+					}
+					
+					return {
+						label: `Season ${season.season_number}`,
+						href: `/tv/${options.mediaId}/${season.season_number}`,
+						isActive: season.season_number === options.seasonNumber,
+						badge: rivenSeason ? statesName[rivenSeason.state] : undefined
+					};
+				});
+		}
+
+		items.push(seasonItem);
+	}
+
+	// Add episode if available
+	if (options.episodeNumber !== undefined && options.mediaType === 'tv') {
+		const episodeItem: BreadcrumbItem = {
+			label: options.episodeTitle || `Episode ${options.episodeNumber}`,
+			href: `/tv/${options.mediaId}/${options.seasonNumber}/${options.episodeNumber}`,
+			isActive: true
+		};
+
+		// Add dropdown for other episodes if available
+		if (options.allEpisodes && options.allEpisodes.length > 1) {
+			// Get the current season's riven data
+			let currentSeasonRivenData = null;
+			if (options.rivenData) {
+				if (options.rivenData.episodes) {
+					// We already have season-level data
+					currentSeasonRivenData = options.rivenData;
+				} else if (options.rivenData.seasons) {
+					// We have show-level data, find the current season
+					currentSeasonRivenData = options.rivenData.seasons.find((s: any) => s.number === options.seasonNumber);
+				}
+			}
+
+			episodeItem.dropdown = options.allEpisodes
+				.sort((a, b) => a.episode_number - b.episode_number) // Sort by episode number
+				.map(episode => {
+					// Find the riven episode data
+					let rivenEpisode = null;
+					if (currentSeasonRivenData && currentSeasonRivenData.episodes) {
+						rivenEpisode = currentSeasonRivenData.episodes.find((e: any) => e.number === episode.episode_number);
+					}
+					
+					return {
+						label: `E${episode.episode_number}: ${episode.name || `Episode ${episode.episode_number}`}`,
+						href: `/tv/${options.mediaId}/${options.seasonNumber}/${episode.episode_number}`,
+						isActive: episode.episode_number === options.episodeNumber,
+						badge: rivenEpisode ? statesName[rivenEpisode.state] : undefined
+					};
+				});
+		}
+
+		items.push(episodeItem);
+	}
+
+	return items;
+} 

--- a/src/routes/[type=mediaType]/[id]/+page.svelte
+++ b/src/routes/[type=mediaType]/[id]/+page.svelte
@@ -2,6 +2,8 @@
 	import type { PageData } from './$types';
 	import { getFormattedTime, isRivenShow } from '$lib/utils.js';
 	import Header from '$lib/components/header.svelte';
+	import NavigationBreadcrumb from '$lib/components/navigation-breadcrumb.svelte';
+	import { buildBreadcrumbs } from '$lib/utils/breadcrumb';
 	import { Badge } from '$lib/components/ui/badge';
 	import {
 		Star,
@@ -42,6 +44,15 @@
 	let selectedItems: Selected<MediaItem>[] = [];
 
 	$: selectedIds = getSelectedIds(selectedItems);
+
+	// Build breadcrumb items
+	$: breadcrumbItems = buildBreadcrumbs({
+		mediaType: data.mediaType as 'movie' | 'tv',
+		mediaId: data.mediaID,
+		mediaTitle: data.details.title || data.details.name || data.details.original_name,
+		allSeasons: data.details.seasons,
+		rivenData: data.riven
+	});
 
 	const getSelectedIds = (selectedItems: Selected<MediaItem>[]): Set<string> =>
 		new Set(selectedItems.map((selected) => selected.value.id));
@@ -167,6 +178,9 @@
 	</div>
 	<div class="absolute z-[2] mt-32 flex h-full w-full flex-col items-center p-8 md:px-24 lg:px-32">
 		<div class="mx-auto flex w-full max-w-7xl flex-col">
+			<div class="mb-6">
+				<NavigationBreadcrumb items={breadcrumbItems} />
+			</div>
 			<div class="flex w-full flex-col items-center md:flex-row md:items-start">
 				<div class="w-[180px] flex-shrink-0 overflow-hidden md:w-[25%]">
 					<div

--- a/src/routes/[type=mediaType]/[id]/[season]/+page.ts
+++ b/src/routes/[type=mediaType]/[id]/[season]/+page.ts
@@ -35,8 +35,14 @@ export const load = (async ({ fetch, params }) => {
 			return Promise.resolve(null);
 		}
 		const anyData = data as any;
-		return anyData.seasons.find((seasonItem: any) => seasonItem.number === season);
+		// Return both the current season and the full show data
+		return {
+			currentSeason: anyData.seasons.find((seasonItem: any) => seasonItem.number === season),
+			fullShow: anyData
+		};
 	}
+
+	const rivenData = await getMediaItemDetails(id);
 
 	return {
 		details: await getDetails(id, season),
@@ -44,6 +50,7 @@ export const load = (async ({ fetch, params }) => {
 		mediaType: type,
 		mediaID: id,
 		seasonNumber: season,
-		riven: await getMediaItemDetails(id)
+		riven: rivenData?.currentSeason || null,
+		rivenShow: rivenData?.fullShow || null
 	};
 }) satisfies PageLoad;

--- a/src/routes/[type=mediaType]/[id]/[season]/[episode]/+page.svelte
+++ b/src/routes/[type=mediaType]/[id]/[season]/[episode]/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import type { PageData } from './$types';
 	import Header from '$lib/components/header.svelte';
+	import NavigationBreadcrumb from '$lib/components/navigation-breadcrumb.svelte';
+	import { buildBreadcrumbs } from '$lib/utils/breadcrumb';
 	import {
 		Star,
 		Trash2,
@@ -29,6 +31,19 @@
 	import { getFormattedTime } from '$lib/utils';
 
 	export let data: PageData;
+
+	// Build breadcrumb items
+	$: breadcrumbItems = buildBreadcrumbs({
+		mediaType: 'tv',
+		mediaId: data.mediaID,
+		mediaTitle: data.mediaDetails.name || data.mediaDetails.original_name,
+		seasonNumber: data.seasonNumber,
+		episodeNumber: data.episodeNumber,
+		episodeTitle: data.details.name,
+		allSeasons: data.mediaDetails.seasons,
+		allEpisodes: data.seasonDetails.episodes,
+		rivenData: data.rivenSeason || data.riven
+	});
 
 	async function deleteItem(id: number) {
 		const response = await ItemsService.removeItem({
@@ -130,6 +145,9 @@
 	</div>
 	<div class="absolute z-[2] mt-32 flex h-full w-full flex-col items-center p-8 md:px-24 lg:px-32">
 		<div class="mx-auto flex w-full max-w-7xl flex-col">
+			<div class="mb-6">
+				<NavigationBreadcrumb items={breadcrumbItems} />
+			</div>
 			<div class="flex w-full flex-col items-center md:flex-row md:items-start">
 				<div class="w-[180px] flex-shrink-0 overflow-hidden md:w-[25%]">
 					<div


### PR DESCRIPTION
# Add Breadcrumb Navigation to Media Pages

## Summary
This PR adds a breadcrumb navigation component to improve user navigation across movie, TV show, season, and episode pages in the Riven frontend.

## Features Added

### 🎯 Breadcrumb Navigation Component
- **Hierarchical Navigation**: Shows the full path from Library → Media Type → Show/Movie → Season → Episode
- **Interactive Dropdowns**: Quick navigation between siblings (seasons/episodes) without going back
- **Status Badges**: Visual indicators showing the download/completion status of items in dropdowns
- **Active State Highlighting**: Clear indication of the current page in the navigation hierarchy
- **Library Icon**: Uses a browse icon (from lucide-svelte) for the Library link

### 📍 Integration Points
The breadcrumb navigation has been integrated into:
- Movie/TV show detail pages (`/[type=mediaType]/[id]/+page.svelte`)
- Season pages (`/[type=mediaType]/[id]/[season]/+page.svelte`)
- Episode pages (`/[type=mediaType]/[id]/[season]/[episode]/+page.svelte`)

## Implementation Details

### New Files Created
1. **`src/lib/components/navigation-breadcrumb.svelte`**
   - Main breadcrumb component with dropdown support
   - Handles rendering of breadcrumb items with optional dropdown menus
   - Shows status badges for media items

2. **`src/lib/utils/breadcrumb.ts`**
   - Utility function for building breadcrumb data structures
   - Handles different media types and hierarchies
   - Maps TV show types correctly for API compatibility

### Modified Files
1. **Season and Episode Page Loaders** (`+page.ts`)
   - Updated to return both current item data and full show data
   - Enables status badges to work correctly in dropdowns

2. **Season and Episode Page Components** (`+page.svelte`)
   - Added breadcrumb navigation at the top of each page
   - Fixed TypeScript type annotations in templates

## Screenshots

### TV Show Page with Breadcrumb Navigation
![TV Show Breadcrumb](https://i.imgur.com/OLCjpFv.png)

### Season Page with Dropdown
![Season Breadcrumb with Dropdown](https://i.imgur.com/ZJdYqcK.png)

### Episode Page Full Navigation with Drowpdown
![Episode Breadcrumb](https://i.imgur.com/ilfth9p.png)

### Episode Page Full Navigation without Drowpdown
![Season Dropdown](https://i.imgur.com/UMiujIj.png)

## Example Navigation Paths
- **Movie**: Library → Movies → Inception
- **TV Show**: Library → TV Shows → Dragon Ball
- **Season**: Library → TV Shows → Dragon Ball → Season 1
- **Episode**: Library → TV Shows → Dragon Ball → Season 1 → Episode 12

## Technical Notes
- The component uses the existing Riven dark theme and styling
- Status badges use the existing `statesName` constants from the codebase

## Testing
- ✅ Tested navigation across all media types
- ✅ Verified dropdown functionality for seasons and episodes
- ✅ Confirmed status badges display correctly
- ✅ Checked responsive design on different screen sizes

## Breaking Changes
None - this is a purely additive feature that doesn't modify existing functionality.

## Future Enhancements
- Could add keyboard navigation support for dropdowns
- Potential to add search within dropdowns for shows with many seasons/episodes
- Could cache dropdown data for better performance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced breadcrumb navigation across media detail, season, and episode pages for improved navigation and context.
  - Added a new breadcrumb UI component with support for dropdowns and badges.
- **Enhancements**
  - Breadcrumbs dynamically display hierarchical navigation for movies and TV shows, including seasons and episodes.
  - Improved episode and season state display with modularized helper functions.
- **Chores**
  - Updated ignored files in project configuration for better development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->