### PR TITLE
Fix layout

### DIFF
--- a/src/lib/components/sidebar.svelte
+++ b/src/lib/components/sidebar.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import * as Avatar from '$lib/components/ui/avatar/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Separator } from '$lib/components/ui/separator/index.js';
 	import Home from '@lucide/svelte/icons/home';
 	import LayoutDashboard from '@lucide/svelte/icons/layout-dashboard';
-	import Settings from '@lucide/svelte/icons/settings';
-	import User from '@lucide/svelte/icons/user';
 	import LogOut from '@lucide/svelte/icons/log-out';
 	import Mountain from '@lucide/svelte/icons/mountain';
-	import { Button } from '$lib/components/ui/button/index.js';
+	import Settings from '@lucide/svelte/icons/settings';
+	import User from '@lucide/svelte/icons/user';
 	import Tooltip from './tooltip.svelte';
-	import * as Avatar from '$lib/components/ui/avatar/index.js';
-	import { Separator } from '$lib/components/ui/separator/index.js';
 
 	const navItems = [
 		{ href: '/', icon: Home, label: 'Home' },
@@ -22,7 +22,7 @@
 </script>
 
 <aside
-	class="bg-card border-r-border fixed top-0 left-0 flex h-screen w-16 flex-col items-center border-r"
+	class="bg-card border-r-border top-0 left-0 flex h-screen w-16 flex-col items-center border-r"
 >
 	<div class="flex h-18 w-full items-center justify-center">
 		<div class="text-primary-foreground flex size-10 items-center justify-center">

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-	import '../../app.css';
-	import type { LayoutProps } from './$types';
+	import { afterNavigate, beforeNavigate } from '$app/navigation';
+	import Sidebar from '$lib/components/sidebar.svelte';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Separator } from '$lib/components/ui/separator/index.js';
 	import { Toaster } from '$lib/components/ui/sonner/index.js';
 	import { ModeWatcher } from 'mode-watcher';
-	import { afterNavigate, beforeNavigate } from '$app/navigation';
 	import NProgress from 'nprogress';
-	import { Separator } from '$lib/components/ui/separator/index.js';
-	import { Input } from '$lib/components/ui/input/index.js';
-	import Sidebar from '$lib/components/sidebar.svelte';
+	import '../../app.css';
+	import type { LayoutProps } from './$types';
 
 	let { data, children }: LayoutProps = $props();
 
@@ -29,16 +29,16 @@
 <ModeWatcher defaultMode={'dark'} />
 <Toaster richColors closeButton />
 
-<div class="bg-background flex min-h-screen">
+<div class="bg-background grid h-screen w-screen grid-cols-[auto_1fr] overflow-hidden">
 	<Sidebar user={data.user} />
-	<main class="ml-16 flex flex-1 flex-col">
-		<header class="bg-card flex h-18 items-center px-4">
+	<main class="grid grid-rows-[auto_auto_1fr] overflow-hidden">
+		<header class="bg-card flex h-18 w-full items-center px-4">
 			<div class="w-full">
 				<Input type="text" placeholder="Search..." class="h-9" />
 			</div>
 		</header>
 		<Separator class="w-full" />
-		<div class="flex-1">
+		<div class="size-full overflow-x-hidden overflow-y-auto">
 			{@render children?.()}
 		</div>
 	</main>


### PR DESCRIPTION
- Replaced `flex` with `grid` for the main layout container to ensure proper alignment and spacing.
- Added `overflow-hidden` to the main layout to prevent overflow issues.
- Removed `fixed` positioning from the sidebar. This allows the sidebar to function as a proper grid item.