### PR TITLE
ci: implement retry logic for Docker Hub push

### DIFF
--- a/.github/workflows/docker-frontend-build-dev.yml
+++ b/.github/workflows/docker-frontend-build-dev.yml
@@ -151,8 +151,23 @@ jobs:
                   docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
                     $(printf '${{ env.REGISTRY_IMAGE_GHCR }}@sha256:%s ' *)
 
-                  docker buildx imagetools create $(jq -cr '.tags | map(gsub("ghcr.io/rivenmedia"; "docker.io/spoked") | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-                   $(printf '${{ env.REGISTRY_IMAGE_DOCKERHUB }}@sha256:%s ' *)
+                  # Push to Docker Hub with retry logic
+                  for attempt in {1..3}; do
+                    echo "Attempt $attempt of 3: Pushing to Docker Hub..."
+                    if docker buildx imagetools create $(jq -cr '.tags | map(gsub("ghcr.io/rivenmedia"; "docker.io/spoked") | "-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+                       $(printf '${{ env.REGISTRY_IMAGE_DOCKERHUB }}@sha256:%s ' *); then
+                      echo "Successfully pushed to Docker Hub"
+                      break
+                    else
+                      if [ $attempt -lt 3 ]; then
+                        echo "Push failed, waiting 15 seconds before retry..."
+                        sleep 15
+                      else
+                        echo "All retry attempts failed"
+                        exit 1
+                      fi
+                    fi
+                  done
 
             - name: Inspect image
               run: |


### PR DESCRIPTION
## issue
A race condition in Docker Hub can cause some concurrent push operations to fail when multiple tags reference the same underlying image data

## Solution
Added retry logic (3 attempts with 15-second delays) specifically for the Docker Hub manifest push. The GHCR push remains unchanged as it's consistently reliable. This is a cheap, simple fix. **If** this doesn't work, we can make the push sequential, but obviously that will be a bit slower.

## Changes
- Wrapped Docker Hub `imagetools create` command in a retry loop
- Added logging to show retry attempts in workflow output
- Maintains fail-fast behavior if all 3 attempts fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker image build process reliability with automatic retry logic for push operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->