### PR TITLE
fix: temporarily disable provenance for Docker build.

### DIFF
--- a/.github/workflows/docker-frontend-build-dev.yml
+++ b/.github/workflows/docker-frontend-build-dev.yml
@@ -80,7 +80,8 @@ jobs:
                   file: ./Dockerfile
                   platforms: ${{ matrix.platform }}
                   labels: ${{ steps.meta.outputs.labels }}
-                  provenance: mode=max
+                  # temp disable provenance
+                  provenance: false
                   outputs: type=image,name=${{ env.REGISTRY_IMAGE_GHCR }},push-by-digest=true,name-canonical=true,push=true
                   cache-from: type=gha,scope=${{ github.workflow }}-${{ env.PLATFORM_PAIR }}
                   cache-to: type=gha,mode=max,scope=${{ github.workflow }}-${{ env.PLATFORM_PAIR }}


### PR DESCRIPTION
Temporarily disable provenance for Docker build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development Docker build configuration for the frontend service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->