### PR TITLE
fix: improve season button opacity based on selection state

### DIFF
--- a/src/routes/(protected)/details/media/[id]/[mediaType]/+page.svelte
+++ b/src/routes/(protected)/details/media/[id]/[mediaType]/+page.svelte
@@ -341,7 +341,7 @@
                         class="border-border flex flex-wrap gap-4 rounded-lg border bg-white/10 px-6 py-4 shadow-lg">
                         {#each data.mediaDetails?.details.seasons as season (season.id)}
                             <button onclick={() => (selectedSeason = season.number?.toString())}>
-                                <div class={{"relative": true, "opacity-50": selectedSeason !== season.number?.toString()}}>
+                                <div class={cn("relative", selectedSeason !== season.number?.toString() && "opacity-50")}>
                                     {#if season.image}
                                         <img
                                             alt={season.id.toString()}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated season cards on the media details page so non-selected seasons appear faded (reduced opacity) for clearer visual distinction; selection behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->