### PR TITLE
fix: request status not updating + scroll position lost on back navigation

### DIFF
--- a/src/lib/components/media/riven/item-request.svelte
+++ b/src/lib/components/media/riven/item-request.svelte
@@ -2,17 +2,6 @@
     import providers from "$lib/providers";
     import { toast } from "svelte-sonner";
     import { invalidateAll } from "$app/navigation";
-
-    async function refreshAfterRequest() {
-        pending = true;
-        try {
-            // Give Riven backend time to process the request
-            await new Promise((r) => setTimeout(r, 1500));
-            await invalidateAll();
-        } finally {
-            pending = false;
-        }
-    }
     import * as AlertDialog from "$lib/components/ui/alert-dialog/index.js";
     import { Button } from "$lib/components/ui/button/index.js";
     import Loader2 from "@lucide/svelte/icons/loader-2";
@@ -21,6 +10,19 @@
     import { createScopedLogger } from "$lib/logger";
     import { type Snippet } from "svelte";
     import { SvelteSet } from "svelte/reactivity";
+
+    async function refreshAfterRequest() {
+        pending = true;
+        try {
+            // Give Riven backend time to process the request
+            await new Promise((r) => setTimeout(r, 1500));
+            await invalidateAll();
+        } catch (err) {
+            logger.error("Failed to refresh after request", err);
+        } finally {
+            pending = false;
+        }
+    }
 
     const logger = createScopedLogger("item-request");
 

--- a/src/lib/components/media/riven/item-request.svelte
+++ b/src/lib/components/media/riven/item-request.svelte
@@ -5,10 +5,13 @@
 
     async function refreshAfterRequest() {
         pending = true;
-        // Give Riven backend time to process the request
-        await new Promise((r) => setTimeout(r, 1500));
-        await invalidateAll();
-        pending = false;
+        try {
+            // Give Riven backend time to process the request
+            await new Promise((r) => setTimeout(r, 1500));
+            await invalidateAll();
+        } finally {
+            pending = false;
+        }
     }
     import * as AlertDialog from "$lib/components/ui/alert-dialog/index.js";
     import { Button } from "$lib/components/ui/button/index.js";
@@ -187,7 +190,7 @@
         <AlertDialog.Footer>
             <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
             <AlertDialog.Action
-                disabled={loading ||
+                disabled={loading || pending ||
                     (mediaType === "tv" &&
                         seasons.length > 0 &&
                         hasRequestableSeasons &&

--- a/src/lib/components/media/riven/item-request.svelte
+++ b/src/lib/components/media/riven/item-request.svelte
@@ -107,7 +107,7 @@
                     // adjust check based on actual response
                     toast.success("Media item requested successfully!");
                     open = false;
-                    refreshAfterRequest();
+                    void refreshAfterRequest();
                 } else {
                     logger.error("Error response:", response.error);
                     toast.error("Failed to request media item.");
@@ -123,7 +123,7 @@
                 if (response.data) {
                     toast.success("Retry requested successfully!");
                     open = false;
-                    refreshAfterRequest();
+                    void refreshAfterRequest();
                 } else {
                     logger.error("Error response:", response.error);
                     toast.error("Failed to retry media item.");
@@ -143,7 +143,7 @@
                 if (response.data) {
                     toast.success("Media item requested successfully!");
                     open = false;
-                    refreshAfterRequest();
+                    void refreshAfterRequest();
                 } else {
                     logger.error("Error response:", response.error);
                     toast.error("Failed to request media item.");

--- a/src/lib/components/media/riven/item-request.svelte
+++ b/src/lib/components/media/riven/item-request.svelte
@@ -1,6 +1,15 @@
 <script lang="ts">
     import providers from "$lib/providers";
     import { toast } from "svelte-sonner";
+    import { invalidateAll } from "$app/navigation";
+
+    async function refreshAfterRequest() {
+        pending = true;
+        // Give Riven backend time to process the request
+        await new Promise((r) => setTimeout(r, 1500));
+        await invalidateAll();
+        pending = false;
+    }
     import * as AlertDialog from "$lib/components/ui/alert-dialog/index.js";
     import { Button } from "$lib/components/ui/button/index.js";
     import Loader2 from "@lucide/svelte/icons/loader-2";
@@ -47,6 +56,7 @@
 
     let open = $state(false);
     let loading = $state(false);
+    let pending = $state(false);
 
     // State for season selection - managed by SeasonSelector component
     let selectedSeasons = $state<SvelteSet<number>>(new SvelteSet());
@@ -92,6 +102,7 @@
                     // adjust check based on actual response
                     toast.success("Media item requested successfully!");
                     open = false;
+                    refreshAfterRequest();
                 } else {
                     logger.error("Error response:", response.error);
                     toast.error("Failed to request media item.");
@@ -107,6 +118,7 @@
                 if (response.data) {
                     toast.success("Retry requested successfully!");
                     open = false;
+                    refreshAfterRequest();
                 } else {
                     logger.error("Error response:", response.error);
                     toast.error("Failed to retry media item.");
@@ -126,6 +138,7 @@
                 if (response.data) {
                     toast.success("Media item requested successfully!");
                     open = false;
+                    refreshAfterRequest();
                 } else {
                     logger.error("Error response:", response.error);
                     toast.error("Failed to request media item.");
@@ -141,8 +154,11 @@
 <AlertDialog.Root bind:open>
     <AlertDialog.Trigger>
         {#snippet child({ props })}
-            <Button {variant} {size} class={className} {...restProps} {...props}>
-                {#if children}
+            <Button {variant} {size} class={className} disabled={pending} {...restProps} {...props}>
+                {#if pending}
+                    <Loader2 class="mr-1.5 h-4 w-4 animate-spin" />
+                    Requesting...
+                {:else if children}
                     {@render children()}
                 {:else}
                     {buttonLabel}

--- a/src/routes/(protected)/+layout.svelte
+++ b/src/routes/(protected)/+layout.svelte
@@ -8,6 +8,9 @@
     import "@fontsource/merriweather/latin.css";
     import oxanium400Woff2 from "@fontsource/oxanium/files/oxanium-latin-400-normal.woff2?url";
     import { afterNavigate, beforeNavigate } from "$app/navigation";
+
+    // Save scroll positions per URL for back-navigation restore
+    const scrollPositions = new Map<string, number>();
     import Sidebar from "$lib/components/sidebar.svelte";
     import { Toaster } from "$lib/components/ui/sonner/index.js";
     import { ModeWatcher } from "mode-watcher";
@@ -31,12 +34,29 @@
     NProgress.configure({
         showSpinner: false
     });
-    beforeNavigate(() => {
+    beforeNavigate((navigation) => {
         NProgress.start();
+        // Save scroll position before leaving
+        if (mainContent && navigation.from?.url) {
+            scrollPositions.set(navigation.from.url.pathname + navigation.from.url.search, mainContent.scrollTop);
+        }
     });
-    afterNavigate(() => {
+    afterNavigate((navigation) => {
         NProgress.done();
-        if (mainContent) mainContent.scrollTop = 0;
+        if (!mainContent) return;
+        if (navigation.type === 'popstate') {
+            // Restore saved scroll position on back/forward
+            const key = navigation.to?.url?.pathname + (navigation.to?.url?.search || '');
+            const saved = key ? scrollPositions.get(key) : undefined;
+            if (saved !== undefined) {
+                // Wait for content to render before restoring
+                requestAnimationFrame(() => {
+                    mainContent.scrollTop = saved;
+                });
+            }
+        } else {
+            mainContent.scrollTop = 0;
+        }
     });
 
     setContext("sidebarStore", SidebarStore);

--- a/src/routes/(protected)/+layout.svelte
+++ b/src/routes/(protected)/+layout.svelte
@@ -10,9 +10,6 @@
     import { afterNavigate, beforeNavigate } from "$app/navigation";
     import { SvelteMap } from "svelte/reactivity";
     import Sidebar from "$lib/components/sidebar.svelte";
-
-    // Save scroll positions per URL for back-navigation restore
-    const scrollPositions = new SvelteMap<string, number>();
     import { Toaster } from "$lib/components/ui/sonner/index.js";
     import { ModeWatcher } from "mode-watcher";
     import NProgress from "nprogress";
@@ -24,6 +21,9 @@
     import MobileNav from "$lib/components/mobile-nav.svelte";
     import { SearchStore } from "$lib/services/search-store.svelte";
     import { FilterStore } from "$lib/services/filter-store.svelte";
+
+    // Save scroll positions per URL for back-navigation restore
+    const scrollPositions = new SvelteMap<string, number>();
 
     let { data, children }: LayoutProps = $props();
 
@@ -50,12 +50,10 @@
             const toUrl = navigation.to?.url;
             const key = toUrl ? toUrl.pathname + (toUrl.search || '') : undefined;
             const saved = key ? scrollPositions.get(key) : undefined;
-            if (saved !== undefined) {
-                // Wait for content to render before restoring
-                requestAnimationFrame(() => {
-                    mainContent.scrollTop = saved;
-                });
-            }
+            // Wait for content to render before restoring
+            requestAnimationFrame(() => {
+                mainContent.scrollTop = saved ?? 0;
+            });
         } else {
             mainContent.scrollTop = 0;
         }

--- a/src/routes/(protected)/+layout.svelte
+++ b/src/routes/(protected)/+layout.svelte
@@ -46,7 +46,8 @@
         if (!mainContent) return;
         if (navigation.type === 'popstate') {
             // Restore saved scroll position on back/forward
-            const key = navigation.to?.url?.pathname + (navigation.to?.url?.search || '');
+            const toUrl = navigation.to?.url;
+            const key = toUrl ? toUrl.pathname + (toUrl.search || '') : undefined;
             const saved = key ? scrollPositions.get(key) : undefined;
             if (saved !== undefined) {
                 // Wait for content to render before restoring

--- a/src/routes/(protected)/+layout.svelte
+++ b/src/routes/(protected)/+layout.svelte
@@ -8,10 +8,11 @@
     import "@fontsource/merriweather/latin.css";
     import oxanium400Woff2 from "@fontsource/oxanium/files/oxanium-latin-400-normal.woff2?url";
     import { afterNavigate, beforeNavigate } from "$app/navigation";
+    import { SvelteMap } from "svelte/reactivity";
+    import Sidebar from "$lib/components/sidebar.svelte";
 
     // Save scroll positions per URL for back-navigation restore
-    const scrollPositions = new Map<string, number>();
-    import Sidebar from "$lib/components/sidebar.svelte";
+    const scrollPositions = new SvelteMap<string, number>();
     import { Toaster } from "$lib/components/ui/sonner/index.js";
     import { ModeWatcher } from "mode-watcher";
     import NProgress from "nprogress";


### PR DESCRIPTION
## What this PR fixes

### 1. Request button not reflecting status after submitting
After clicking 'Request' on a movie/show, the button would briefly close the dialog but return to showing 'Request' again — giving no feedback that the request was processed.

**Fix:** Added a loading spinner ("Requesting...") with a 1.5s delay + `invalidateAll()` to refresh page data after the backend has processed the request. The button is disabled during this time to prevent double-submits.

### 2. Scroll position lost on back navigation  
Navigating to a detail page and pressing back would always reset scroll to the top, losing the user's position in long lists (e.g. library, search results).

**Fix:** Scroll positions are saved per-URL in a Map before navigation and restored on `popstate` (back/forward) events using `requestAnimationFrame` to avoid race conditions with content rendering.

### Files changed
- `src/lib/components/media/riven/item-request.svelte` — loading state + auto-refresh
- `src/routes/(protected)/+layout.svelte` — scroll position save/restore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shows a spinner and disables the request button while an item request is in progress to improve feedback.
  * Remembers and restores page scroll position when navigating back; other navigations reset to top. Navigation progress indicator remains active.

* **Bug Fixes**
  * Automatically refreshes displayed data after successful item requests to keep content current.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->