### PR TITLE
feat: fullscreen search modal + back button for mobile

### DIFF
--- a/src/lib/components/mobile-nav.svelte
+++ b/src/lib/components/mobile-nav.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
     import Menu from "@lucide/svelte/icons/menu";
     import X from "@lucide/svelte/icons/x";
+    import ChevronLeft from "@lucide/svelte/icons/chevron-left";
     import { Button } from "$lib/components/ui/button/index.js";
     import NotificationCenter from "$lib/components/notification-center.svelte";
-    import { getContext, onDestroy } from "svelte";
+    import SearchModal from "$lib/components/search-modal.svelte";
+    import { getContext } from "svelte";
     import Search from "@lucide/svelte/icons/search";
-    import { goto } from "$app/navigation";
     import { page } from "$app/state";
     import type { createSidebarStore } from "$lib/stores/global.svelte";
     import { fly } from "svelte/transition";
@@ -13,29 +14,22 @@
 
     const SidebarStore = getContext<createSidebarStore>("sidebarStore");
 
-    let inputRef = $state<HTMLInputElement | null>(null);
-    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+    const MAIN_PAGES = ["/", "/explore", "/dashboard", "/library", "/settings", "/calendar", "/logs"];
 
-    function navigateToSearch() {
-        if (debounceTimer) clearTimeout(debounceTimer);
-        const query = inputRef?.value.trim() || "";
-        const currentlyExplore = page.url.pathname === "/explore";
-        goto(query ? `/explore?query=${encodeURIComponent(query)}` : "/explore", {
-            keepFocus: currentlyExplore,
-            noScroll: true,
-            replaceState: currentlyExplore
-        });
-    }
+    const isMainPage = $derived(MAIN_PAGES.includes(page.url.pathname));
 
-    function handleInput() {
-        if (debounceTimer) clearTimeout(debounceTimer);
-        debounceTimer = setTimeout(navigateToSearch, 300);
-    }
-
-    onDestroy(() => {
-        if (debounceTimer) clearTimeout(debounceTimer);
-    });
+    let searchModalOpen = $state(false);
 </script>
+
+{#if !isMainPage}
+    <button
+        transition:fly={{ y: -20, duration: 400, easing: cubicOut }}
+        onclick={() => history.back()}
+        aria-label="Go back"
+        class="fixed top-4 left-4 z-[60] flex h-10 w-10 items-center justify-center rounded-full border border-white/5 bg-white/5 shadow-lg backdrop-blur-xl transition-all duration-300 hover:bg-white/10 active:scale-95 md:hidden">
+        <ChevronLeft class="size-5 text-white/70" />
+    </button>
+{/if}
 
 <div
     transition:fly={{ y: 20, duration: 400, easing: cubicOut }}
@@ -46,22 +40,13 @@
         <!-- Search Icon -->
         <Search class="size-4 shrink-0 text-white/50" />
 
-        <!-- Input -->
-        <input
-            bind:this={inputRef}
-            name="query"
-            placeholder="Search..."
-            aria-label="Search"
-            value={page.url.searchParams.get("query") || ""}
-            oninput={handleInput}
-            onkeydown={(e) => {
-                if (e.key === "Enter") {
-                    e.preventDefault();
-                    navigateToSearch();
-                }
-            }}
-            class="text-foreground h-full flex-1 bg-transparent text-sm font-medium outline-none placeholder:text-white/40"
-            autocomplete="off" />
+        <!-- Tap-to-search trigger -->
+        <button
+            onclick={() => (searchModalOpen = true)}
+            aria-label="Open search"
+            class="h-full flex-1 bg-transparent text-left text-sm font-medium text-white/40 outline-none">
+            Search...
+        </button>
 
         <!-- Actions Divider -->
         <div class="h-5 w-px bg-white/10"></div>
@@ -100,3 +85,5 @@
         </div>
     </div>
 </div>
+
+<SearchModal open={searchModalOpen} onclose={() => (searchModalOpen = false)} onopen={() => (searchModalOpen = true)} />

--- a/src/lib/components/mobile-nav.svelte
+++ b/src/lib/components/mobile-nav.svelte
@@ -6,6 +6,7 @@
     import NotificationCenter from "$lib/components/notification-center.svelte";
     import SearchModal from "$lib/components/search-modal.svelte";
     import { getContext } from "svelte";
+    import { goto } from "$app/navigation";
     import Search from "@lucide/svelte/icons/search";
     import { page } from "$app/state";
     import type { createSidebarStore } from "$lib/stores/global.svelte";
@@ -24,7 +25,13 @@
 {#if !isMainPage}
     <button
         transition:fly={{ y: -20, duration: 400, easing: cubicOut }}
-        onclick={() => history.back()}
+        onclick={() => {
+            if (history.length > 1) {
+                history.back();
+            } else {
+                goto('/');
+            }
+        }}
         aria-label="Go back"
         class="fixed top-4 left-4 z-[60] flex h-10 w-10 items-center justify-center rounded-full border border-white/5 bg-white/5 shadow-lg backdrop-blur-xl transition-all duration-300 hover:bg-white/10 active:scale-95 md:hidden">
         <ChevronLeft class="size-5 text-white/70" />

--- a/src/lib/components/mobile-nav.svelte
+++ b/src/lib/components/mobile-nav.svelte
@@ -16,7 +16,7 @@
 
     const SidebarStore = getContext<createSidebarStore>("sidebarStore");
 
-    const MAIN_PAGES = ["/", "/explore", "/dashboard", "/library", "/settings", "/calendar", "/logs"];
+    const MAIN_PAGES = ["/", "/explore", "/dashboard", "/library", "/settings", "/calendar", "/logs", "/auth"];
 
     const isMainPage = $derived(MAIN_PAGES.includes(page.url.pathname));
 

--- a/src/lib/components/mobile-nav.svelte
+++ b/src/lib/components/mobile-nav.svelte
@@ -7,6 +7,7 @@
     import SearchModal from "$lib/components/search-modal.svelte";
     import { getContext } from "svelte";
     import { goto } from "$app/navigation";
+    import { resolve } from "$app/paths";
     import Search from "@lucide/svelte/icons/search";
     import { page } from "$app/state";
     import type { createSidebarStore } from "$lib/stores/global.svelte";
@@ -29,7 +30,7 @@
             if (history.length > 1) {
                 history.back();
             } else {
-                goto('/');
+                goto(resolve('/'));
             }
         }}
         aria-label="Go back"

--- a/src/lib/components/mobile-nav.svelte
+++ b/src/lib/components/mobile-nav.svelte
@@ -94,4 +94,6 @@
     </div>
 </div>
 
-<SearchModal open={searchModalOpen} onclose={() => (searchModalOpen = false)} onopen={() => (searchModalOpen = true)} />
+<div class="md:hidden">
+    <SearchModal open={searchModalOpen} onclose={() => (searchModalOpen = false)} onopen={() => (searchModalOpen = true)} />
+</div>

--- a/src/lib/components/search-modal.svelte
+++ b/src/lib/components/search-modal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { goto, afterNavigate } from "$app/navigation";
+    import { onDestroy } from "svelte";
     import X from "@lucide/svelte/icons/x";
     import Search from "@lucide/svelte/icons/search";
     import PortraitCard from "$lib/components/media/portrait-card.svelte";
@@ -25,6 +26,12 @@
     let results = $state<TMDBTransformedListItem[]>([]);
     let loading = $state(false);
     let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+    let abortController: AbortController | null = null;
+
+    onDestroy(() => {
+        if (debounceTimer) clearTimeout(debounceTimer);
+        abortController?.abort();
+    });
     let abortController: AbortController | null = null;
 
     // Persist search state across navigation
@@ -184,7 +191,7 @@
         <div class="flex-1 overflow-y-auto">
             {#if loading}
                 <div class="grid grid-cols-2 gap-3 px-4 pt-4 pb-24">
-                    {#each Array(8) as _, i (i)}
+                    {#each Array.from({ length: 8 }, (_, i) => i) as i (i)}
                         <PortraitCardSkeleton />
                     {/each}
                 </div>

--- a/src/lib/components/search-modal.svelte
+++ b/src/lib/components/search-modal.svelte
@@ -1,0 +1,217 @@
+<script lang="ts">
+    import { goto, afterNavigate } from "$app/navigation";
+    import X from "@lucide/svelte/icons/x";
+    import Search from "@lucide/svelte/icons/search";
+    import PortraitCard from "$lib/components/media/portrait-card.svelte";
+    import PortraitCardSkeleton from "$lib/components/media/portrait-card-skeleton.svelte";
+    import { fly, fade } from "svelte/transition";
+    import { cubicOut } from "svelte/easing";
+    import type { TMDBTransformedListItem } from "$lib/providers/parser";
+
+    interface Props {
+        open: boolean;
+        onclose: () => void;
+        onopen: () => void;
+    }
+
+    let { open, onclose, onopen }: Props = $props();
+
+    function reopenFromNav() {
+        onopen();
+    }
+
+    let inputRef = $state<HTMLInputElement | null>(null);
+    let query = $state("");
+    let results = $state<TMDBTransformedListItem[]>([]);
+    let loading = $state(false);
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+    let abortController: AbortController | null = null;
+
+    // Persist search state across navigation
+    let savedQuery = "";
+    let savedResults: TMDBTransformedListItem[] = [];
+    let navigatedFromModal = false;
+    // When true, skip transitions (instant hide/show for navigation)
+    let skipTransition = $state(false);
+
+    $effect(() => {
+        if (open && inputRef) {
+            // Restore previous search if available
+            if (savedQuery && !query) {
+                query = savedQuery;
+                results = savedResults;
+            }
+            inputRef.focus();
+        }
+    });
+
+    function handleInput() {
+        if (debounceTimer) clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(search, 300);
+    }
+
+    async function search() {
+        const q = query.trim();
+        if (!q) {
+            results = [];
+            loading = false;
+            return;
+        }
+
+        if (abortController) abortController.abort();
+        abortController = new AbortController();
+        const signal = abortController.signal;
+
+        loading = true;
+        try {
+            const params = new URLSearchParams({ query: q, searchMode: "search", page: "1" });
+            const [movieRes, tvRes] = await Promise.all([
+                fetch(`/api/tmdb/search/movie?${params}`, { signal }),
+                fetch(`/api/tmdb/search/tv?${params}`, { signal })
+            ]);
+
+            if (signal.aborted) return;
+
+            const [movies, tv] = await Promise.all([
+                movieRes.ok ? movieRes.json() : { results: [] },
+                tvRes.ok ? tvRes.json() : { results: [] }
+            ]);
+
+            if (signal.aborted) return;
+
+            const merged: TMDBTransformedListItem[] = [
+                ...(movies.results ?? []),
+                ...(tv.results ?? [])
+            ].sort((a, b) => (b.popularity ?? 0) - (a.popularity ?? 0));
+
+            results = merged;
+        } catch (err) {
+            if (err instanceof Error && err.name === "AbortError") return;
+            results = [];
+        } finally {
+            if (!signal.aborted) loading = false;
+        }
+    }
+
+    let pendingNavigation = false;
+
+    function handleResultClick(item: TMDBTransformedListItem) {
+        savedQuery = query;
+        savedResults = results;
+        navigatedFromModal = true;
+        pendingNavigation = true;
+        // Keep modal open — it will be hidden after the new page loads
+        goto(`/details/media/${item.id}/${item.media_type}`);
+    }
+
+    afterNavigate((navigation) => {
+        if (pendingNavigation) {
+            // New page loaded — now hide the modal instantly
+            pendingNavigation = false;
+            skipTransition = true;
+            onclose();
+            requestAnimationFrame(() => { skipTransition = false; });
+            return;
+        }
+        if (navigation.type === 'popstate' && navigatedFromModal && savedQuery) {
+            navigatedFromModal = false;
+            skipTransition = true;
+            reopenFromNav();
+            requestAnimationFrame(() => { skipTransition = false; });
+        }
+    });
+
+    function handleKeydown(e: KeyboardEvent) {
+        if (e.key === "Escape") clearAndClose();
+    }
+
+    function clearAndClose() {
+        savedQuery = "";
+        savedResults = [];
+        query = "";
+        results = [];
+        onclose();
+    }
+
+    function getSubtitle(item: TMDBTransformedListItem): string {
+        const parts: string[] = [];
+        if (item.media_type === "movie") parts.push("Movie");
+        else if (item.media_type === "tv") parts.push("TV");
+        if (item.year && item.year !== "N/A") parts.push(String(item.year));
+        return parts.join(" • ");
+    }
+</script>
+
+{#if open}
+    <!-- Backdrop -->
+    <div
+        transition:fade={{ duration: skipTransition ? 0 : 200 }}
+        class="fixed inset-0 z-[70] bg-zinc-950/98 backdrop-blur-xl"
+        role="presentation">
+    </div>
+
+    <!-- Modal Content -->
+    <div
+        transition:fly={{ y: skipTransition ? 0 : 20, duration: skipTransition ? 0 : 300, easing: cubicOut }}
+        class="fixed inset-0 z-[71] flex flex-col overflow-hidden"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Search">
+        <!-- Header -->
+        <div class="flex shrink-0 items-center gap-3 border-b border-white/5 px-4 py-3">
+            <Search class="size-4 shrink-0 text-white/50" />
+            <!-- svelte-ignore a11y_autofocus -->
+            <input
+                bind:this={inputRef}
+                bind:value={query}
+                oninput={handleInput}
+                onkeydown={handleKeydown}
+                placeholder="Search movies & shows..."
+                aria-label="Search"
+                autocomplete="off"
+                autofocus
+                enterkeyhint="search"
+                class="h-full flex-1 bg-transparent text-sm font-medium text-white outline-none placeholder:text-white/40" />
+            <button
+                onclick={clearAndClose}
+                aria-label="Close search"
+                class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-white/50 transition-all hover:bg-white/10 hover:text-white active:scale-95">
+                <X class="size-5" />
+            </button>
+        </div>
+
+        <!-- Results -->
+        <div class="flex-1 overflow-y-auto">
+            {#if loading}
+                <div class="grid grid-cols-2 gap-3 px-4 pt-4 pb-24">
+                    {#each Array(8) as _, i (i)}
+                        <PortraitCardSkeleton />
+                    {/each}
+                </div>
+            {:else if results.length > 0}
+                <div class="grid grid-cols-2 gap-3 px-4 pt-4 pb-24">
+                    {#each results as item (`${item.media_type}-${item.id}`)}
+                        <button
+                            onclick={() => handleResultClick(item)}
+                            class="block w-full rounded-xl text-left outline-none focus-visible:ring-2 focus-visible:ring-white/50 active:scale-[0.97] transition-transform duration-150">
+                            <PortraitCard
+                                title={item.title}
+                                subtitle={getSubtitle(item)}
+                                image={item.poster_path} />
+                        </button>
+                    {/each}
+                </div>
+            {:else if query.trim() && !loading}
+                <div class="flex flex-col items-center justify-center gap-2 py-24 text-center">
+                    <p class="text-white/60 text-base font-medium">No results found</p>
+                    <p class="text-white/30 text-sm">Try a different search term</p>
+                </div>
+            {:else}
+                <div class="flex flex-col items-center justify-center gap-2 py-24 text-center">
+                    <Search class="size-8 text-white/20" />
+                    <p class="text-white/40 text-sm">Start typing to search</p>
+                </div>
+            {/if}
+        </div>
+    </div>
+{/if}

--- a/src/lib/components/search-modal.svelte
+++ b/src/lib/components/search-modal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { goto, afterNavigate } from "$app/navigation";
+    import { resolve } from "$app/paths";
     import { onDestroy } from "svelte";
     import X from "@lucide/svelte/icons/x";
     import Search from "@lucide/svelte/icons/search";
@@ -32,7 +33,6 @@
         if (debounceTimer) clearTimeout(debounceTimer);
         abortController?.abort();
     });
-    let abortController: AbortController | null = null;
 
     // Persist search state across navigation
     let savedQuery = "";
@@ -108,7 +108,7 @@
         navigatedFromModal = true;
         pendingNavigation = true;
         // Keep modal open — it will be hidden after the new page loads
-        goto(`/details/media/${item.id}/${item.media_type}`);
+        goto(resolve(`/details/media/${item.id}/${item.media_type}`));
     }
 
     afterNavigate((navigation) => {
@@ -133,10 +133,17 @@
     }
 
     function clearAndClose() {
+        if (debounceTimer) {
+            clearTimeout(debounceTimer);
+            debounceTimer = null;
+        }
+        abortController?.abort();
+        abortController = null;
         savedQuery = "";
         savedResults = [];
         query = "";
         results = [];
+        loading = false;
         onclose();
     }
 

--- a/src/lib/components/search-modal.svelte
+++ b/src/lib/components/search-modal.svelte
@@ -10,6 +10,8 @@
     import { cubicOut } from "svelte/easing";
     import type { TMDBTransformedListItem } from "$lib/providers/parser";
 
+    const MAX_RESULTS = 20;
+
     interface Props {
         open: boolean;
         onclose: () => void;
@@ -84,6 +86,13 @@
 
             if (signal.aborted) return;
 
+            if (!movieRes.ok) {
+                console.error(`TMDB movie search failed: ${movieRes.status} ${movieRes.statusText}`);
+            }
+            if (!tvRes.ok) {
+                console.error(`TMDB TV search failed: ${tvRes.status} ${tvRes.statusText}`);
+            }
+
             const [movies, tv] = await Promise.all([
                 movieRes.ok ? movieRes.json() : { results: [] },
                 tvRes.ok ? tvRes.json() : { results: [] }
@@ -94,7 +103,8 @@
             const merged: TMDBTransformedListItem[] = [
                 ...(movies.results ?? []),
                 ...(tv.results ?? [])
-            ].sort((a, b) => (b.popularity ?? 0) - (a.popularity ?? 0));
+            ].sort((a, b) => (b.popularity ?? 0) - (a.popularity ?? 0))
+             .slice(0, MAX_RESULTS);
 
             results = merged;
         } catch (err) {
@@ -198,6 +208,7 @@
                 enterkeyhint="search"
                 class="h-full flex-1 bg-transparent text-sm font-medium text-white outline-none placeholder:text-white/40" />
             <button
+                type="button"
                 onclick={clearAndClose}
                 aria-label="Close search"
                 class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-white/50 transition-all hover:bg-white/10 hover:text-white active:scale-95">
@@ -217,6 +228,7 @@
                 <div class="grid grid-cols-2 gap-3 px-4 pt-4 pb-24">
                     {#each results as item (`${item.media_type}-${item.id}`)}
                         <button
+                            type="button"
                             onclick={() => handleResultClick(item)}
                             class="block w-full rounded-xl text-left outline-none focus-visible:ring-2 focus-visible:ring-white/50 active:scale-[0.97] transition-transform duration-150">
                             <PortraitCard

--- a/src/lib/components/search-modal.svelte
+++ b/src/lib/components/search-modal.svelte
@@ -38,6 +38,7 @@
     let savedQuery = "";
     let savedResults: TMDBTransformedListItem[] = [];
     let navigatedFromModal = false;
+    let savedOrigin = "";
     // When true, skip transitions (instant hide/show for navigation)
     let skipTransition = $state(false);
 
@@ -54,12 +55,16 @@
 
     function handleInput() {
         if (debounceTimer) clearTimeout(debounceTimer);
+        abortController?.abort();
+        abortController = null;
         debounceTimer = setTimeout(search, 300);
     }
 
     async function search() {
         const q = query.trim();
         if (!q) {
+            abortController?.abort();
+            abortController = null;
             results = [];
             loading = false;
             return;
@@ -107,6 +112,7 @@
         savedResults = results;
         navigatedFromModal = true;
         pendingNavigation = true;
+        savedOrigin = window.location.pathname + window.location.search;
         // Keep modal open — it will be hidden after the new page loads
         goto(resolve(`/details/media/${item.id}/${item.media_type}`));
     }
@@ -121,10 +127,15 @@
             return;
         }
         if (navigation.type === 'popstate' && navigatedFromModal && savedQuery) {
-            navigatedFromModal = false;
-            skipTransition = true;
-            reopenFromNav();
-            requestAnimationFrame(() => { skipTransition = false; });
+            const toUrl = navigation.to?.url;
+            const currentPath = toUrl ? toUrl.pathname + (toUrl.search || '') : '';
+            if (currentPath === savedOrigin) {
+                navigatedFromModal = false;
+                savedOrigin = "";
+                skipTransition = true;
+                reopenFromNav();
+                requestAnimationFrame(() => { skipTransition = false; });
+            }
         }
     });
 

--- a/src/lib/components/search-modal.svelte
+++ b/src/lib/components/search-modal.svelte
@@ -62,6 +62,8 @@
         if (debounceTimer) clearTimeout(debounceTimer);
         abortController?.abort();
         abortController = null;
+        currentPage = 1;
+        hasMorePages = true;
         debounceTimer = setTimeout(() => search(true), 300);
     }
 
@@ -75,6 +77,7 @@
             hasMorePages = true;
             currentQuery = "";
             loading = false;
+            loadingMore = false;
             return;
         }
 

--- a/src/lib/components/search-modal.svelte
+++ b/src/lib/components/search-modal.svelte
@@ -10,8 +10,6 @@
     import { cubicOut } from "svelte/easing";
     import type { TMDBTransformedListItem } from "$lib/providers/parser";
 
-    const MAX_RESULTS = 20;
-
     interface Props {
         open: boolean;
         onclose: () => void;
@@ -25,11 +23,16 @@
     }
 
     let inputRef = $state<HTMLInputElement | null>(null);
+    let scrollContainer = $state<HTMLElement | null>(null);
     let query = $state("");
     let results = $state<TMDBTransformedListItem[]>([]);
     let loading = $state(false);
+    let loadingMore = $state(false);
     let debounceTimer: ReturnType<typeof setTimeout> | null = null;
     let abortController: AbortController | null = null;
+    let currentPage = 1;
+    let hasMorePages = true;
+    let currentQuery = "";
 
     onDestroy(() => {
         if (debounceTimer) clearTimeout(debounceTimer);
@@ -59,26 +62,43 @@
         if (debounceTimer) clearTimeout(debounceTimer);
         abortController?.abort();
         abortController = null;
-        debounceTimer = setTimeout(search, 300);
+        debounceTimer = setTimeout(() => search(true), 300);
     }
 
-    async function search() {
+    async function search(reset: boolean) {
         const q = query.trim();
         if (!q) {
             abortController?.abort();
             abortController = null;
             results = [];
+            currentPage = 1;
+            hasMorePages = true;
+            currentQuery = "";
             loading = false;
             return;
         }
+
+        if (reset) {
+            currentPage = 1;
+            hasMorePages = true;
+            currentQuery = q;
+        }
+
+        if (!hasMorePages) return;
 
         if (abortController) abortController.abort();
         abortController = new AbortController();
         const signal = abortController.signal;
 
-        loading = true;
+        if (reset) {
+            loading = true;
+        } else {
+            loadingMore = true;
+        }
+
         try {
-            const params = new URLSearchParams({ query: q, searchMode: "search", page: "1" });
+            const page = String(currentPage);
+            const params = new URLSearchParams({ query: q, searchMode: "search", page });
             const [movieRes, tvRes] = await Promise.all([
                 fetch(`/api/tmdb/search/movie?${params}`, { signal }),
                 fetch(`/api/tmdb/search/tv?${params}`, { signal })
@@ -94,24 +114,45 @@
             }
 
             const [movies, tv] = await Promise.all([
-                movieRes.ok ? movieRes.json() : { results: [] },
-                tvRes.ok ? tvRes.json() : { results: [] }
+                movieRes.ok ? movieRes.json() : { results: [], total_pages: 0 },
+                tvRes.ok ? tvRes.json() : { results: [], total_pages: 0 }
             ]);
 
             if (signal.aborted) return;
 
+            const maxTotalPages = Math.max(movies.total_pages ?? 0, tv.total_pages ?? 0);
+            hasMorePages = currentPage < maxTotalPages;
+
             const merged: TMDBTransformedListItem[] = [
                 ...(movies.results ?? []),
                 ...(tv.results ?? [])
-            ].sort((a, b) => (b.popularity ?? 0) - (a.popularity ?? 0))
-             .slice(0, MAX_RESULTS);
+            ].sort((a, b) => (b.popularity ?? 0) - (a.popularity ?? 0));
 
-            results = merged;
+            if (reset) {
+                results = merged;
+            } else {
+                // Deduplicate by id+media_type
+                const seen = new Set(results.map(r => `${r.media_type}-${r.id}`));
+                results = [...results, ...merged.filter(r => !seen.has(`${r.media_type}-${r.id}`))];
+            }
+            currentPage++;
         } catch (err) {
             if (err instanceof Error && err.name === "AbortError") return;
-            results = [];
+            if (reset) results = [];
         } finally {
-            if (!signal.aborted) loading = false;
+            if (!signal.aborted) {
+                loading = false;
+                loadingMore = false;
+            }
+        }
+    }
+
+    function handleScroll(e: Event) {
+        const el = e.target as HTMLElement;
+        if (loadingMore || loading || !hasMorePages || !currentQuery) return;
+        // Load more when within 300px of bottom
+        if (el.scrollHeight - el.scrollTop - el.clientHeight < 300) {
+            void search(false);
         }
     }
 
@@ -165,6 +206,10 @@
         query = "";
         results = [];
         loading = false;
+        loadingMore = false;
+        currentPage = 1;
+        hasMorePages = true;
+        currentQuery = "";
         onclose();
     }
 
@@ -217,7 +262,10 @@
         </div>
 
         <!-- Results -->
-        <div class="flex-1 overflow-y-auto">
+        <div
+            bind:this={scrollContainer}
+            onscroll={handleScroll}
+            class="flex-1 overflow-y-auto">
             {#if loading}
                 <div class="grid grid-cols-2 gap-3 px-4 pt-4 pb-24">
                     {#each Array.from({ length: 8 }, (_, i) => i) as i (i)}
@@ -237,6 +285,11 @@
                                 image={item.poster_path} />
                         </button>
                     {/each}
+                    {#if loadingMore}
+                        {#each Array.from({ length: 4 }, (_, i) => i) as i (i)}
+                            <PortraitCardSkeleton />
+                        {/each}
+                    {/if}
                 </div>
             {:else if query.trim() && !loading}
                 <div class="flex flex-col items-center justify-center gap-2 py-24 text-center">


### PR DESCRIPTION
## What this PR adds

### Fullscreen search modal for mobile
Replaces the inline search input in the mobile navbar with a fullscreen modal overlay. This solves several UX issues on mobile:

- **Keyboard stays open** — no more keyboard closing/reopening when navigating between search and results
- **Search state persists** — tap a result → view details → press back → modal reopens with your previous search and results intact
- **No page flash** — modal stays visible until the destination page has fully loaded (previously you'd see the home page briefly during navigation)
- **Clean dismiss** — Escape or X button clears the search entirely

#### How it works
- Tapping the search bar opens a fullscreen overlay with auto-focusing input
- 300ms debounced search via TMDB API (movies + TV merged, sorted by popularity)
- Results displayed as portrait cards in a responsive 2-column grid
- Navigation to a result saves the query/results; `afterNavigate` with `popstate` detection reopens the modal on back
- Transitions are instant during navigation (skip animations) but smooth for manual open/close

### Back button on mobile
Adds a chevron-left button (top-left, glass-morphism style) on non-main pages. Hidden on main navigation pages (/, /explore, /dashboard, /library, /settings, /calendar, /logs).

### Files
- **New:** `src/lib/components/search-modal.svelte` — the fullscreen search overlay
- **Modified:** `src/lib/components/mobile-nav.svelte` — search trigger + back button

### Screenshots
Mobile-only changes. Desktop search is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile search now opens in a dedicated modal that restores saved query/results, focuses input on open, supports keyboard close (Esc), debounced typing with concurrent movie+TV lookups and in-flight request handling, shows loading/empty states, and navigates to details when a result is selected.

* **Refactor**
  * Mobile nav redesigned: search converted from inline input to tap-to-open modal and a conditional top-left back button added (uses history back with fallback to home).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->