### PR TITLE
refactor(tvdb): manage session at the API client, drop the per-request hook

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,14 +1,11 @@
 import { auth } from "$lib/server/auth";
-import { redirect, error, type Handle, type ServerInit } from "@sveltejs/kit";
+import { redirect, type Handle, type ServerInit } from "@sveltejs/kit";
 import { svelteKitHandler } from "better-auth/svelte-kit";
 import { building } from "$app/environment";
 import { sequence } from "@sveltejs/kit/hooks";
 import { env } from "$env/dynamic/private";
-import providers from "$lib/providers";
-import { dev } from "$app/environment";
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";
 import { db } from "$lib/server/db";
-import { createCustomFetch } from "$lib/custom-fetch";
 import { createScopedLogger } from "$lib/logger";
 
 const logger = createScopedLogger("hooks");
@@ -51,33 +48,8 @@ const configureLocals: Handle = async ({ event, resolve }) => {
     return resolve(event);
 };
 
-const handleTVDBCookie: Handle = async ({ event, resolve }) => {
-    const tvdbCookie = event.cookies.get("tvdb_cookie");
-
-    if (!tvdbCookie) {
-        const customFetch = createCustomFetch(event.fetch);
-        const tvdbLogin = await providers.tvdb.POST("/login", {
-            body: {
-                apikey: "6be85335-5c4f-4d8d-b945-d3ed0eb8cdce"
-            },
-            fetch: customFetch
-        });
-
-        if (tvdbLogin.error) {
-            error(500, "Failed to login to TVDB: " + tvdbLogin.error);
-        } else {
-            event.cookies.set("tvdb_cookie", tvdbLogin.data?.data?.token || "", {
-                path: "/",
-                httpOnly: true,
-                sameSite: "lax",
-                secure: !dev,
-                maxAge: 60 * 60 * 24 * 30 // 30 days
-            });
-            logger.info("Set TVDB cookie");
-        }
-    }
-
-    return resolve(event);
-};
-
-export const handle: Handle = sequence(configureLocals, betterAuthHandler, handleTVDBCookie);
+// TVDB session management used to live here as `handleTVDBCookie`. It now
+// lives at `$lib/server/tvdb-session.ts` and is wired into `providers.tvdb`
+// via the openapi-fetch `fetch` option, so callers don't need to read a
+// cookie or attach an Authorization header. See PR description for context.
+export const handle: Handle = sequence(configureLocals, betterAuthHandler);

--- a/src/lib/providers/index.ts
+++ b/src/lib/providers/index.ts
@@ -17,14 +17,18 @@ import type { paths as TraktPaths } from "./trakt";
 import type { paths as RivenPaths } from "./riven";
 import { parseTMDBMovieDetails, parseTVDBShowDetails } from "./parser";
 import { customFetch } from "$lib/custom-fetch";
+import { tvdbFetch } from "$lib/server/tvdb-session";
 
 const rivenClient = createClient<RivenPaths>({
     baseUrl: ""
 });
 
+// `tvdbFetch` automatically injects the bearer token and refreshes on 401, so
+// callers no longer need to read the `tvdb_cookie` or set Authorization
+// headers manually.
 const tvdbClient = createClient<TVDBPaths>({
     baseUrl: "https://api4.thetvdb.com/v4",
-    fetch: customFetch
+    fetch: tvdbFetch
 });
 
 const TMDB_READ_ACCESS_TOKEN =

--- a/src/lib/server/tvdb-session.ts
+++ b/src/lib/server/tvdb-session.ts
@@ -1,0 +1,164 @@
+import { createCustomFetch } from "$lib/custom-fetch";
+import { createScopedLogger } from "$lib/logger";
+
+/**
+ * In-process TVDB session management.
+ *
+ * Replaces the previous per-request `handleTVDBCookie` SvelteKit hook with a
+ * lazy, in-process token cache that the TVDB API client uses transparently.
+ *
+ * Caller-visible behavior:
+ *   - On the first call to a TVDB endpoint that needs auth, a token is fetched
+ *     from `/login` and cached in module memory.
+ *   - Subsequent calls reuse the cached token.
+ *   - If TVDB returns 401, the token is invalidated and refreshed once before
+ *     the request is retried.
+ *   - When TVDB is unreachable or refuses to issue a token, the module backs
+ *     off for a minute so we don't hammer the API on every request, and
+ *     callers see degraded responses (no Authorization header) rather than a
+ *     thrown exception.
+ *
+ * Why this shape:
+ *   - The hook approach made every request pay a synchronous TVDB round-trip
+ *     (or appear to, depending on cookie state), even on routes that didn't
+ *     touch TVDB.
+ *   - The hook's `error(500, ...)` on TVDB failure took down the whole
+ *     frontend (issue #301), including `/auth/login` itself, even though
+ *     TVDB enrichment is best-effort.
+ *   - Putting session management at the API client layer means individual
+ *     callers don't need to know about cookies, headers, or refresh; they
+ *     just call `providers.tvdb.GET(...)`.
+ */
+
+const logger = createScopedLogger("tvdb-session");
+
+// Same key the hook used. The TVDB v4 docs recommend pinning a single project
+// API key and reusing the resulting bearer token across requests.
+const TVDB_API_KEY = "6be85335-5c4f-4d8d-b945-d3ed0eb8cdce";
+const TVDB_LOGIN_URL = "https://api4.thetvdb.com/v4/login";
+
+// One minute backoff between login attempts when TVDB is unhappy. Prevents a
+// stampede on every request during a TVDB outage. Tunable; matches the value
+// the hook-era patch used for the same reason.
+const TOKEN_REFRESH_BACKOFF_MS = 60 * 1000;
+
+const baseFetch = createCustomFetch();
+
+let cachedToken: string | null = null;
+let refreshBackoffUntil = 0;
+// Single-flight: if a refresh is already underway, all concurrent callers
+// await the same promise instead of triggering N parallel `/login` calls.
+let inflight: Promise<string | null> | null = null;
+
+async function fetchToken(): Promise<string | null> {
+    try {
+        const res = await baseFetch(TVDB_LOGIN_URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ apikey: TVDB_API_KEY })
+        });
+
+        if (!res.ok) {
+            logger.warn(`TVDB login returned HTTP ${res.status}`);
+            return null;
+        }
+
+        const json = (await res.json()) as { data?: { token?: string } };
+        return json.data?.token ?? null;
+    } catch (e) {
+        logger.warn(
+            `TVDB login threw: ${e instanceof Error ? e.message : String(e)}`
+        );
+        return null;
+    }
+}
+
+/**
+ * Returns a TVDB bearer token, lazy-acquiring on first call and reusing the
+ * cached value on subsequent calls.
+ *
+ * Pass `force: true` to invalidate the cache and re-acquire (used by
+ * `tvdbFetch` after a 401).
+ *
+ * Returns `null` when TVDB is unreachable or refused to issue a token. Callers
+ * should treat that as a degraded state and either skip TVDB enrichment or
+ * surface a normal "no data" response - never throw.
+ */
+export async function getTvdbToken(force = false): Promise<string | null> {
+    if (!force && cachedToken) {
+        return cachedToken;
+    }
+
+    if (Date.now() < refreshBackoffUntil) {
+        return null;
+    }
+
+    if (inflight) {
+        return inflight;
+    }
+
+    inflight = (async () => {
+        try {
+            const token = await fetchToken();
+            if (token) {
+                cachedToken = token;
+                return token;
+            }
+            refreshBackoffUntil = Date.now() + TOKEN_REFRESH_BACKOFF_MS;
+            return null;
+        } finally {
+            inflight = null;
+        }
+    })();
+
+    return inflight;
+}
+
+/**
+ * Fetch wrapper for the TVDB API client. Injects the bearer token when one
+ * is available and retries once on 401 with a freshly-acquired token.
+ *
+ * Wired into `providers.tvdb` via the openapi-fetch `fetch` option, so all
+ * `providers.tvdb.GET(...)` / `.POST(...)` calls go through it without the
+ * caller needing to know about session state.
+ *
+ * The `/login` endpoint itself bypasses auth injection (otherwise we'd need a
+ * token to obtain the token).
+ */
+export async function tvdbFetch(
+    input: RequestInfo | URL,
+    init?: RequestInit
+): Promise<Response> {
+    const url =
+        typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.href
+              : input.url;
+
+    if (url.endsWith("/login")) {
+        return baseFetch(input, init);
+    }
+
+    const sendWithToken = async (token: string | null) => {
+        const headers = new Headers(init?.headers);
+        if (token && !headers.has("Authorization")) {
+            headers.set("Authorization", `Bearer ${token}`);
+        }
+        return baseFetch(input, { ...init, headers });
+    };
+
+    let token = await getTvdbToken();
+    let response = await sendWithToken(token);
+
+    if (response.status === 401 && token) {
+        // Token might be expired or revoked. Force a refresh and retry once.
+        cachedToken = null;
+        token = await getTvdbToken(true);
+        if (token) {
+            response = await sendWithToken(token);
+        }
+    }
+
+    return response;
+}

--- a/src/lib/services/resolver.ts
+++ b/src/lib/services/resolver.ts
@@ -28,7 +28,6 @@ export interface ResolveOptions {
     to: Indexer;
     id: number | string;
     mediaType: MediaType;
-    tvdbToken?: string;
     customFetch: typeof fetch;
     rivenBaseUrl?: string;
     rivenApiKey?: string;
@@ -96,7 +95,7 @@ async function getMovieExternalIds(tmdbId: number, customFetch: typeof fetch) {
  * TMDB -> TVDB (TV shows only)
  */
 async function tmdbToTvdb(options: ResolveOptions): Promise<ResolveResult> {
-    const { id, mediaType, customFetch, tvdbToken } = options;
+    const { id, mediaType, customFetch } = options;
     const tmdbId = Number(id);
 
     if (mediaType === "movie") {
@@ -121,41 +120,37 @@ async function tmdbToTvdb(options: ResolveOptions): Promise<ResolveResult> {
         logger.warn(`TMDB external_ids failed for ${id}:`, e);
     }
 
-    // Fallback: TVDB search by remote ID (TMDB ID)
-    if (tvdbToken) {
-        try {
-            const { data, error } = await providers.tvdb.GET("/search/remoteid/{remoteId}", {
-                params: { path: { remoteId: String(id) } },
-                headers: { Authorization: `Bearer ${tvdbToken}` },
-                fetch: customFetch
-            });
+    // Fallback: TVDB search by remote ID (TMDB ID). Auth is injected by
+    // `tvdbFetch`; if TVDB is unavailable the call returns an error response
+    // rather than throwing, so we fall through to the next fallback.
+    try {
+        const { data, error } = await providers.tvdb.GET("/search/remoteid/{remoteId}", {
+            params: { path: { remoteId: String(id) } }
+        });
 
-            if (!error) {
-                // Find a series result (ignore movies - we only resolve TV shows)
-                const match = data?.data?.find((r) => r.series)?.series;
-                if (match?.id) {
-                    return { id: Number(match.id), resolved: true };
-                }
+        if (!error) {
+            // Find a series result (ignore movies - we only resolve TV shows)
+            const match = data?.data?.find((r) => r.series)?.series;
+            if (match?.id) {
+                return { id: Number(match.id), resolved: true };
             }
-        } catch (e) {
-            logger.warn(`TVDB remote_id search failed for ${id}:`, e);
         }
+    } catch (e) {
+        logger.warn(`TVDB remote_id search failed for ${id}:`, e);
+    }
 
-        // Final fallback: Check if TMDB ID exists as a TVDB series ID directly
-        // (sometimes IDs match between systems)
-        try {
-            const { data, error } = await providers.tvdb.GET("/series/{id}", {
-                params: { path: { id: tmdbId } },
-                headers: { Authorization: `Bearer ${tvdbToken}` },
-                fetch: customFetch
-            });
+    // Final fallback: Check if TMDB ID exists as a TVDB series ID directly
+    // (sometimes IDs match between systems)
+    try {
+        const { data, error } = await providers.tvdb.GET("/series/{id}", {
+            params: { path: { id: tmdbId } }
+        });
 
-            if (!error && data?.data?.id) {
-                return { id: Number(data.data.id), resolved: true };
-            }
-        } catch {
-            // Series doesn't exist with this ID, that's fine
+        if (!error && data?.data?.id) {
+            return { id: Number(data.data.id), resolved: true };
         }
+    } catch {
+        // Series doesn't exist with this ID, that's fine
     }
 
     logger.warn(`Could not resolve TMDB ${id} to TVDB`);

--- a/src/routes/(protected)/api/tvdb/search/+server.ts
+++ b/src/routes/(protected)/api/tvdb/search/+server.ts
@@ -2,7 +2,6 @@ import type { RequestHandler } from "./$types";
 import { json, error } from "@sveltejs/kit";
 import providers from "$lib/providers";
 import * as dateUtils from "$lib/utils/date";
-import { createCustomFetch } from "$lib/custom-fetch";
 import { createScopedLogger } from "$lib/logger";
 
 const logger = createScopedLogger("tvdb-search");
@@ -64,12 +63,10 @@ function applyServerFilters(items: any[], filters: Record<string, any>): any[] {
     });
 }
 
-export const GET: RequestHandler = async ({ fetch, locals, url, cookies }) => {
+export const GET: RequestHandler = async ({ locals, url }) => {
     if (!locals.user || !locals.session) {
         error(401, "Unauthorized");
     }
-
-    const customFetch = createCustomFetch(fetch);
 
     // Extract all TVDB search parameters from URL
     const query = url.searchParams.get("query") || url.searchParams.get("q");
@@ -115,13 +112,6 @@ export const GET: RequestHandler = async ({ fetch, locals, url, cookies }) => {
         error(400, "Search query or remote_id is required");
     }
 
-    // Get TVDB token from cookie (set by hooks.server.ts)
-    const tvdbToken = cookies.get("tvdb_cookie");
-
-    if (!tvdbToken) {
-        error(500, "TVDB authentication token not available");
-    }
-
     try {
         // Build query parameters - only include defined values
         const searchParams: Record<string, string | number> = {
@@ -139,15 +129,11 @@ export const GET: RequestHandler = async ({ fetch, locals, url, cookies }) => {
         if (network) searchParams.network = network;
         if (remote_id) searchParams.remote_id = remote_id;
 
-        // Make search request to TVDB using the provider client
+        // TVDB auth is injected by `tvdbFetch` (see $lib/server/tvdb-session.ts).
         const searchResult = await providers.tvdb.GET("/search", {
             params: {
                 query: searchParams as any
-            },
-            headers: {
-                Authorization: `Bearer ${tvdbToken}`
-            },
-            fetch: customFetch
+            }
         });
 
         if (searchResult.error) {

--- a/src/routes/(protected)/details/media/[id]/[mediaType]/+page.server.ts
+++ b/src/routes/(protected)/details/media/[id]/[mediaType]/+page.server.ts
@@ -124,7 +124,7 @@ async function getTraktData(fetch: typeof globalThis.fetch, mediaId: string, isM
     }
 }
 
-export const load = (async ({ fetch, params, cookies, locals, url }) => {
+export const load = (async ({ fetch, params, locals, url }) => {
     const { id, mediaType } = params;
     const customFetch = createCustomFetch(fetch);
 
@@ -191,8 +191,6 @@ export const load = (async ({ fetch, params, cookies, locals, url }) => {
                 } as MediaDetails
             };
         } else if (mediaType === "tv") {
-            const tvdbToken = cookies.get("tvdb_cookie") || "";
-
             // Check if the ID is already a TVDB ID (passed via query param from library)
             const indexerParam = url.searchParams.get("indexer");
             const isAlreadyTvdbId = indexerParam === "tvdb";
@@ -203,14 +201,14 @@ export const load = (async ({ fetch, params, cookies, locals, url }) => {
                 // ID is already a TVDB ID, no resolution needed
                 tvdbId = Number(id);
             } else {
-                // Resolve TMDB ID to TVDB ID
+                // Resolve TMDB ID to TVDB ID. TVDB auth is now handled inside
+                // `providers.tvdb`, so this no longer needs a token argument.
                 const resolved = await normalizeFetch(
                     resolveId({
                         from: "tmdb",
                         to: "tvdb",
                         id: Number(id),
                         mediaType: "tv",
-                        tvdbToken,
                         customFetch
                     })
                 );
@@ -244,9 +242,7 @@ export const load = (async ({ fetch, params, cookies, locals, url }) => {
                             params: {
                                 path: { id: tvdbId },
                                 query: { meta: "episodes" }
-                            },
-                            headers: { Authorization: `Bearer ${tvdbToken}` },
-                            fetch: customFetch
+                            }
                         })
                     ),
                     normalizeFetch(
@@ -254,9 +250,7 @@ export const load = (async ({ fetch, params, cookies, locals, url }) => {
                             params: {
                                 path: { id: tvdbId },
                                 query: { meta: "translations" }
-                            },
-                            headers: { Authorization: `Bearer ${tvdbToken}` },
-                            fetch: customFetch
+                            }
                         })
                     ),
                     getTraktData(customFetch, String(tvdbId), false),
@@ -315,11 +309,7 @@ export const load = (async ({ fetch, params, cookies, locals, url }) => {
                                 query: {
                                     page: 0
                                 }
-                            },
-                            headers: {
-                                Authorization: `Bearer ${tvdbToken}`
-                            },
-                            fetch: customFetch
+                            }
                         })
                     );
 


### PR DESCRIPTION
> [!NOTE]
> Force-pushed to replace v1. Previous version was a small targeted fix that route-scoped `handleTVDBCookie` and made it non-fatal. @Mini suggested in chat that the right shape is treating the TVDB session as a credential lifecycle managed at the API client layer, not as a per-request hook concern. This rewrite does that.

Closes #301.

## Architecture

**Before**
- `hooks.server.ts → handleTVDBCookie` ran on every request, called `/login` when the cookie was missing, set the cookie, and `error(500)`'d the entire request on TVDB failure (the bug behind #301: a slow or unreachable TVDB took down `/auth/login` itself).
- Every caller read the cookie and manually attached `Authorization: Bearer ${tvdbToken}` to TVDB requests.

**After**
- `$lib/server/tvdb-session.ts`: lazy in-process token cache with 60s failure backoff, single-flight refresh, and a `tvdbFetch` wrapper that injects the bearer token and retries once on 401.
- `$lib/providers/index.ts`: `tvdbClient` is wired with `fetch: tvdbFetch`, so `providers.tvdb.GET(...)` handles auth transparently.
- `hooks.server.ts`: hook removed. Sequence is just `configureLocals → betterAuthHandler`.
- Callers (`resolver.ts`, `/details/.../+page.server.ts`, `/api/tvdb/search/+server.ts`): no more cookie reads, no more Authorization headers, no more `tvdbToken` parameter on `resolveId`.

## Diff scope

```
 src/hooks.server.ts                                |  40 +----
 src/lib/providers/index.ts                         |   6 +-
 src/lib/server/tvdb-session.ts                     | 164 +++++++++++++++++++++
 src/lib/services/resolver.ts                       |  61 ++++----
 src/routes/(protected)/api/tvdb/search/+server.ts  |  20 +--
 .../details/media/[id]/[mediaType]/+page.server.ts |  22 +--
 6 files changed, 212 insertions(+), 101 deletions(-)
```

## What this fixes

1. **Issue #301**: TVDB outages no longer 500 the frontend. `tvdbFetch` returns the (degraded) response and callers move on; nothing throws.
2. **Per-request log noise**: zero `[hooks] Set TVDB cookie` lines in normal operation.
3. **Per-request TVDB round-trip** on cookie-less hits for routes that never touch TVDB: also gone.
4. **Token rotation**: v1 had no story for expiry. The interceptor refreshes on 401 transparently.

## What this preserves

- Same project API key as the previous hook.
- Same TVDB endpoints and response handling at every call site.
- Server-only module placement: `$lib/server/tvdb-session.ts` never ships to the client; the cached token never crosses the network.

## Notes

- No tests added. The existing test footprint for SvelteKit hooks and provider clients is light, and most of the new behavior is load-bearingly tied to TVDB's runtime response. Happy to add a focused unit test that mocks `baseFetch` if you'd prefer one before merging.
- The legacy `tvdb_cookie` becomes unused; it expires in 30 days on its own. Didn't add a `cookies.delete` call since it's harmless. Can add one if cleanliness matters.
- Acknowledging the riven-ts deprecation context: this still helps anyone on `:dev` until cutover, and the architecture matches what you'd want regardless of which repo lands long-term.